### PR TITLE
Fixed #36, added redraw throtteling (fixes #30)

### DIFF
--- a/css/wisegui.css
+++ b/css/wisegui.css
@@ -139,7 +139,7 @@ input.success {
 }
 
 #WiseGuiNotificationsButton {
-	width: 80px;
+	width: 120px;
 	margin-left: 0;
 }
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 	<script type="text/javascript" src="js/lib/jquery.tablesorter-2.0.5.min.js"></script>
 	<script type="text/javascript" src="js/lib/jquery.dateformat-1.0.js"></script>
 	<script type="text/javascript" src="js/lib/jquery.timePicker-20110318.js"></script>
+	<script type="text/javascript" src="js/lib/jquery.ba-throttle-debounce.min.js"></script>
 
 	<script type="text/javascript" src="js/lib/jquery-ui.min.1.8.17.js"></script>
 

--- a/js/lib/jquery.ba-throttle-debounce.min.js
+++ b/js/lib/jquery.ba-throttle-debounce.min.js
@@ -1,0 +1,9 @@
+/*
+ * jQuery throttle / debounce - v1.1 - 3/7/2010
+ * http://benalman.com/projects/jquery-throttle-debounce-plugin/
+ * 
+ * Copyright (c) 2010 "Cowboy" Ben Alman
+ * Dual licensed under the MIT and GPL licenses.
+ * http://benalman.com/about/license/
+ */
+(function(b,c){var $=b.jQuery||b.Cowboy||(b.Cowboy={}),a;$.throttle=a=function(e,f,j,i){var h,d=0;if(typeof f!=="boolean"){i=j;j=f;f=c}function g(){var o=this,m=+new Date()-d,n=arguments;function l(){d=+new Date();j.apply(o,n)}function k(){h=c}if(i&&!h){l()}h&&clearTimeout(h);if(i===c&&m>e){l()}else{if(f!==true){h=setTimeout(i?k:l,i===c?e-m:e)}}}if($.guid){g.guid=j.guid=j.guid||$.guid++}return g};$.debounce=function(d,e,f){return f===c?a(d,e,false):a(d,f,e!==false)}})(this);


### PR DESCRIPTION
Messages are always received and stored but calling the redraw function is now limited.
Standard is set to a minimum of 200ms between two succinct redraws. 
This would also imply, that you can only see new messages every 200ms.
The value can be changed in the output options.

You can try out the changes at the [gh-pages site](http://wisebed.github.com/wisegui).
